### PR TITLE
Add location as search parameter to the cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Requires Node v4+
 
 ```bash
 # Installation
-$ npm i zom -g 
+$ npm i zom -g
 # Usage
-$ zom Starbucks
+$ zom Starbucks@Delhi
 Starbucks (⭐️ ⭐️ ⭐️  3.9 Very Good)
     🕸  https://www.zomato.com/ncr/starbucks-1-connaught-place-new-delhi?utm_source=api_basic_user&utm_medium=api&utm_campaign=v2.1
     🗺A Block A, Hamilton House, Connaught Place, New Delhi
@@ -33,7 +33,7 @@ Why not ? 🙃
 
 Seriously though, sometimes team parties are decided mid work and it's great to not to have to open browser and search when you can simply use a quick CLI tool.
 
-### Todo 
+### Todo
 * [ ] Use `~/.zomatoclirc` to save settings like location etc
 * [ ] Use client location if not specified.
 * [ ] Add parameters for better searches

--- a/index.js
+++ b/index.js
@@ -4,11 +4,31 @@ const fetch = require('node-fetch');
 
 const key = '17c5c4c6e845e73f4296fa83b502b87c';
 
-const keyword = process.argv.splice(2).join(' ') || 'Big Yellow Door';
+const args = (process.argv.splice(2).join(' ') || 'Big Yellow Door@Delhi').split('@');
+
+if (args.length == 1) {
+  args.splice(1, 0, 'Delhi');
+} else if (args.length == 2) {
+  if (args[0] === '' || args[1] === '') {
+    console.log('Usage: zom <keyword>[@<location>]');
+    return;
+  }
+} else {
+  console.log('Usage: zom <keyword>[@<location>]');
+  return;
+}
+
+const { location, keyword } = { location: args[1], keyword: args[0] };
+
+const extractLocationData = e => new Promise((resolve, reject) => {
+  let locationData = e.location_suggestions[0] || { entity_id: 1, entity_type: 'city' }
+
+  resolve(locationData);
+});
 
 const extractRestaurants = e => new Promise((resolve, reject) => resolve(e.restaurants.map(e => e.restaurant)));
 
-const printRestaurants = r => r.map(e => console.log(e)); 
+const printRestaurants = r => r.map(e => console.log(e));
 
 const stars = rating => "⭐️ ".repeat(parseInt(rating));
 
@@ -22,10 +42,16 @@ const makeHumanReadable = restaurants => new Promise((resolve, reject) => {
     `)));
 });
 
-fetch(`https://developers.zomato.com/api/v2.1/search?entity_id=delhi&q=${keyword}`, {
+fetch(`https://developers.zomato.com/api/v2.1/locations?query=${location}`, {
   method: 'get',
   headers: { 'user-key': key, 'Accept': 'application/json', },
 })
+.then(e => e.json())
+.then(extractLocationData)
+.then(({ entity_id, entity_type }) => fetch(`https://developers.zomato.com/api/v2.1/search?entity_id=${entity_id}&entity_type=${entity_type}&q=${keyword}`, {
+  method: 'get',
+  headers: { 'user-key': key, 'Accept': 'application/json', },
+}))
 .then(e => e.json())
 .then(extractRestaurants)
 .then(makeHumanReadable)


### PR DESCRIPTION
Hey @bogas04 

Just a POC on how we can add location to our search without much command parsing logic/bloat

With these changes, the cli would work as :
```
zom <keyword>[@<location>]
```

For recovery purposes for almost correct queries,
* keyword defaults to 'Big Yellow Door'
* location defaults to `Delhi NCR`

This also sets ground for the `~/.zomatoclirc` feature. Cheers! :tada: 